### PR TITLE
Removes pg_gem from Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,6 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
-    pg_search (2.3.3)
-      activerecord (>= 5.2)
-      activesupport (>= 5.2)
     pr_geohash (1.0.0)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -203,7 +200,6 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
-  pg_search
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   roo (~> 2.8)


### PR DESCRIPTION
Removes pg_gem from Gemfile. Forgot to do it so was unable to run the application on Heroku
